### PR TITLE
Pod install failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "uuid"
   ],
   "author": "Travis Nuttall",
+  "homepage": "https://github.com/Traviskn/react-native-uuid-generator",
   "license": "MIT",
   "peerDependencies": {
     "react-native": ">=0.60"

--- a/react-native-uuid-generator.podspec
+++ b/react-native-uuid-generator.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.platform     = :ios, "9.0"
 
-  s.source       = { :git => "https://github.com/cristianoccazinsp/react-native-uuid-generator", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/cristianoccazinsp/react-native-uuid-generator.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'


### PR DESCRIPTION
Pod installation failed with the next error:

[!] The `react-native-uuid-generator` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
    - WARN  | github_sources: Github repositories should end in `.git`.